### PR TITLE
Fix Max All buying boosts early

### DIFF
--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -234,10 +234,12 @@ function buyGenUpgrade() {
   }
 }
 function maxGenUpgrade() {
-  while (player.errors.gte(costs.boost)) {
-    player.errors=player.errors.sub(costs.boost)
-    player.boostPower+=1
-    updateCosts()
+  if (player.compAmount[2]>0) {
+    while (player.errors.gte(costs.boost)) {
+      player.errors=player.errors.sub(costs.boost)
+      player.boostPower+=1
+      updateCosts()
+    }
   }
 }
 


### PR DESCRIPTION
Before this change, max all would buy the first boost upgrade before buying the first T3 computer. This change prevents it from buying a boost before owning a T3 computer.